### PR TITLE
feat: 공통 JPA BaseEntity 구조 추가

### DIFF
--- a/src/main/java/com/kt/common/jpa/BaseAuditEntity.java
+++ b/src/main/java/com/kt/common/jpa/BaseAuditEntity.java
@@ -1,0 +1,15 @@
+package com.kt.common.jpa;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAuditEntity extends BaseTimeEntity {
+	@CreatedBy
+	protected Long createdBy;
+	@LastModifiedBy
+	protected Long updatedBy;
+}

--- a/src/main/java/com/kt/common/jpa/BaseIdEntity.java
+++ b/src/main/java/com/kt/common/jpa/BaseIdEntity.java
@@ -1,0 +1,15 @@
+package com.kt.common.jpa;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseIdEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id;
+}

--- a/src/main/java/com/kt/common/jpa/BaseTimeEntity.java
+++ b/src/main/java/com/kt/common/jpa/BaseTimeEntity.java
@@ -1,0 +1,20 @@
+package com.kt.common.jpa;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity extends BaseIdEntity {
+	@CreatedDate
+	protected LocalDateTime createdAt;
+	@LastModifiedDate
+	protected LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#8 

## 📝작업 내용

공통 JPA 엔티티 상속 구조(BaseIdEntity, BaseTimeEntity, BaseAuditEntity)를 추가하여 도메인 엔티티의 중복 필드를 제거하고, 추후 Auditing 적용 기반을 마련하는 작업입니다.

## 💬리뷰 요구사항(선택)

추가 요구사항은 없을지 편하게 코멘트 부탁드립니다.
감사합니다.