### PR TITLE
feat: 관리자의 유저 비활성화 로직

### DIFF
--- a/src/main/java/com/kt/controller/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/user/AdminUserController.java
@@ -46,4 +46,10 @@ public class AdminUserController {
         userService.deleteUser(id);
         return ApiResponseEntity.empty();
     }
+
+    @PatchMapping ("/{id}/in-activate")
+    public ApiResponseEntity<Void> activateUser(@PathVariable Long id){
+        userService.inactivateUser(id);
+        return ApiResponseEntity.empty();
+    }
 }

--- a/src/main/java/com/kt/service/user/UserService.java
+++ b/src/main/java/com/kt/service/user/UserService.java
@@ -83,4 +83,8 @@ public class UserService {
 
         user.softDelete();
     }
+
+    public void inactivateUser(Long userId) {
+        deleteUser(userId);
+    }
 }

--- a/src/test/java/com/kt/controller/user/AdminUserControllerTest.java
+++ b/src/test/java/com/kt/controller/user/AdminUserControllerTest.java
@@ -180,4 +180,30 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                     );
         }
     }
+
+    @Nested
+    class 관리자_유저_비활성화_API {
+        @Test
+        void 성공 () throws Exception {
+            mockMvc.perform(
+                    restDocsFactory.createRequest(
+                            ADMIN_USERS_URL+"/"+userId+"/in-activate",
+                            null,
+                            HttpMethod.PATCH,
+                            objectMapper
+                    ).with(jwtAdmin())
+            )
+                    .andExpect(status().isNoContent())
+                    .andDo(
+                            restDocsFactory.success(
+                                    "admin-users-inactivate",
+                                    "유저 비활성화 (관리자)",
+                                    "관리자가 특정 유저를 비활성화하는 API",
+                                    "Admin-user",
+                                    null,
+                                    null
+                            )
+                    );
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

> 관리자의 유저 비활성화 로직 추가 - 기존 회원 탈퇴 메서드 활용
> 테스트 코드 추가

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 관리자가 유저를 비활성화하는 경우는 회원 탈퇴랑 비슷하다 생각해 Soft-delete로 설정을 해 둔 상태인데,
soft delete 말고 따로 inactivate 상태를 추가해 관리하는 것이 좋을 지 고민이 됩니다