### PR TITLE
fix: 관리자의 유저 비활성화 및 관리자 삭제 시 토큰 삭제

### DIFF
--- a/src/main/java/com/kt/controller/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/user/AdminUserController.java
@@ -41,9 +41,11 @@ public class AdminUserController {
 
     @DeleteMapping("/{id}")
     public ApiResponseEntity<Void> deleteMyInfo(
-            @PathVariable Long id
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        userService.deleteUser(id);
+        String accessToken = authorizationHeader.replace("Bearer ", "");
+        userService.deleteUser(id, accessToken);
         return ApiResponseEntity.empty();
     }
 

--- a/src/main/java/com/kt/controller/user/UserController.java
+++ b/src/main/java/com/kt/controller/user/UserController.java
@@ -53,9 +53,11 @@ public class UserController {
 
     @DeleteMapping("/withdrawal")
     public ApiResponseEntity<Void> deleteMyInfo(
-            @AuthenticationPrincipal AuthUser authUser
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        userService.deleteUser(authUser.id());
+        String accessToken = authorizationHeader.replace("Bearer ", "");
+        userService.deleteUser(authUser.id(), accessToken);
         return ApiResponseEntity.empty();
     }
 

--- a/src/main/java/com/kt/repository/user/UserRepository.java
+++ b/src/main/java/com/kt/repository/user/UserRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query("SELECT user FROM User user WHERE user.loginId = :loginId")
+
     Optional<User> findByLoginIdAndDeletedAtIsNull(@Param("loginId") String loginId);
 
     boolean existsByloginId(String loginId);

--- a/src/main/java/com/kt/service/auth/AuthService.java
+++ b/src/main/java/com/kt/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.kt.service.auth;
 
+import com.kt.common.Preconditions;
 import com.kt.common.api.CustomException;
 import com.kt.common.api.ErrorCode;
 import com.kt.domain.user.User;
@@ -91,9 +92,8 @@ public class AuthService {
     }
 
     public void logout(Long userId, String accessToken) {
-        if (!tokenProvider.validateToken(accessToken)) {
-            throw new JwtException(ErrorCode.UNAUTHORIZED_CLIENT.getMessage());
-        }
+
+        Preconditions.validate(tokenProvider.validateToken(accessToken), ErrorCode.UNAUTHORIZED_CLIENT);
 
         String refreshKey = "refreshToken:" + userId;
         redisTemplate.delete(refreshKey);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101 

## 📝작업 내용

> 관리자가 유저 비활성화할 때 유저가 더이상 로그인하지 못하도록 refreshToken 삭제
> 관리자 삭제 시 해당 관리자의 accessToken 블랙리스트 처리 및 refreshToken 삭제

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?