### PR TITLE
refactor: SUPER_ADMIN 권한 추가

### DIFF
--- a/src/main/java/com/kt/common/api/ErrorCode.java
+++ b/src/main/java/com/kt/common/api/ErrorCode.java
@@ -79,6 +79,9 @@ public enum ErrorCode {
 	INVENTORY_RESERVATION_NOT_FOUND(HttpStatus.CONFLICT, "예약된 재고가 부족합니다."),
 	INVENTORY_OUTBOUND_NOT_RESERVED(HttpStatus.CONFLICT, "출고 처리할 예약 재고가 없습니다."),
 
+	// ---------------- CART -------------------
+	CART_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 이미 삭제되어 있습니다"),
+
 	// ---------------- ORDER -------------------
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
 	ORDER_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 주문을 취소할 수 없습니다."),

--- a/src/main/java/com/kt/common/config/SecurityConfig.java
+++ b/src/main/java/com/kt/common/config/SecurityConfig.java
@@ -1,12 +1,12 @@
 package com.kt.common.config;
 
-import com.kt.security.JwtExceptionHandler;
-import com.kt.security.JwtFilter;
-import com.kt.security.TokenProvider;
+import com.kt.security.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -44,15 +44,21 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/users/signup", "/admins/signup", "/", "/auth/login", "/auth/reissue",
-                                "/auth/reset-password/request", "/auth/reset-password/verify", "/auth/reset-password", "/auth/find-id",
-                                "/swagger-ui.html", "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/users/signup", "/", "/auth/login","/auth/reissue","/swagger-ui.html",
+                                "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/super-admin/**").hasRole("SUPER_ADMIN")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().hasAnyRole("USER", "ADMIN"))
-                .logout((logout) -> logout.logoutSuccessUrl("/auth/login")
-                        .invalidateHttpSession(true))
+                        .anyRequest().authenticated())
                 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy("""
+        ROLE_SUPER_ADMIN > ROLE_ADMIN
+        ROLE_ADMIN > ROLE_USER
+    """);
     }
 }

--- a/src/main/java/com/kt/common/config/SecurityConfig.java
+++ b/src/main/java/com/kt/common/config/SecurityConfig.java
@@ -26,6 +26,8 @@ public class SecurityConfig {
     private final TokenProvider tokenProvider;
     private final JwtExceptionHandler jwtExceptionHandler;
     private final RedisTemplate<String, String> redisTemplate;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -41,8 +43,13 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/users/signup", "/", "/auth/login","/auth/reissue","/swagger-ui.html",
                                 "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/kt/controller/cart/CartController.java
+++ b/src/main/java/com/kt/controller/cart/CartController.java
@@ -1,0 +1,63 @@
+package com.kt.controller.cart;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.kt.common.api.ApiResponseEntity;
+import com.kt.dto.cart.CartRequest;
+import com.kt.dto.cart.CartResponse;
+import com.kt.security.AuthUser;
+import com.kt.service.cart.CartService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cart")
+public class CartController {
+
+	private final CartService cartService;
+
+	@PostMapping("/cart-products")
+	public ApiResponseEntity<CartResponse.Create> create(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid CartRequest.Add request
+	){
+		var response = cartService.create(request, authUser.id());
+
+		return ApiResponseEntity.created(response);
+	}
+
+	@GetMapping
+	public ApiResponseEntity<List<CartResponse.Detail>> detail(
+		@AuthenticationPrincipal AuthUser authUser
+	){
+		var response = cartService.detail(authUser.id());
+
+		return ApiResponseEntity.success(response);
+	}
+
+	@DeleteMapping("/cart-products/{id}")
+	public ApiResponseEntity<Void> delete(
+		@AuthenticationPrincipal AuthUser authUser,
+		@PathVariable Long id
+	){
+		cartService.delete(id,authUser.id());
+
+		return ApiResponseEntity.success();
+	}
+
+	//상품 수량 변경
+	@PutMapping("/cart-products/{id}")
+	public ApiResponseEntity<CartResponse.CountUpdate> countUpdate(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid CartRequest.CountUpdate request,
+		@PathVariable Long id
+	){
+		var response = cartService.countUpdate(authUser.id(), request, id);
+		return ApiResponseEntity.success(response);
+	}
+}

--- a/src/main/java/com/kt/controller/user/AdminController.java
+++ b/src/main/java/com/kt/controller/user/AdminController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/admins")
+@RequestMapping("/super-admin")
 @RequiredArgsConstructor
 public class AdminController {
 

--- a/src/main/java/com/kt/controller/user/AdminUserController.java
+++ b/src/main/java/com/kt/controller/user/AdminUserController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/admin/users")
+@RequestMapping("/super-admin/users")
 @RequiredArgsConstructor
 public class AdminUserController {
 

--- a/src/main/java/com/kt/domain/cart/Cart.java
+++ b/src/main/java/com/kt/domain/cart/Cart.java
@@ -1,0 +1,36 @@
+package com.kt.domain.cart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.kt.common.jpa.BaseTimeEntity;
+import com.kt.domain.cartproduct.CartProduct;
+import com.kt.domain.user.User;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "cart")
+@Entity
+@Getter
+@NoArgsConstructor
+public class Cart extends BaseTimeEntity {
+
+	@OneToOne(fetch = FetchType.LAZY) //지연로딩
+	private User user;
+
+	@OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<CartProduct> products = new ArrayList<>();
+
+	//회원 1명당 장바구니 1개
+	private Cart(User user){
+		this.user = user;
+	}
+	public static Cart create(User user){
+
+		return new Cart(user);
+	}
+
+
+}

--- a/src/main/java/com/kt/domain/cartproduct/CartProduct.java
+++ b/src/main/java/com/kt/domain/cartproduct/CartProduct.java
@@ -1,0 +1,55 @@
+package com.kt.domain.cartproduct;
+
+import java.time.LocalDateTime;
+
+import com.kt.common.jpa.BaseTimeEntity;
+import com.kt.domain.cart.Cart;
+import com.kt.domain.product.Product;
+
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "cart_product")
+@Entity
+@Getter
+@NoArgsConstructor
+public class CartProduct extends BaseTimeEntity {
+
+	@ManyToOne
+	private Cart cart;
+	@ManyToOne
+	private Product product;
+	private int count;
+
+	//총금액은 'Order'에서 계산
+
+	private CartProduct(Cart cart, Product product, int count){
+
+		this.cart = cart;
+		this.product = product;
+		this.count = count;
+
+	}
+	//장바구니에 담을 상품 엔티티 생성
+	public static CartProduct create(Cart cart, Product product, int count){
+
+		return new CartProduct(
+			cart,
+			product,
+			count
+		);
+	}
+
+	//장바구니에 담을 수량 증가
+	public void add(int count){
+		this.count += count;
+	}
+
+	//장바구니 상품 수량 변경
+	public void countUpdate(int count){
+		this.count = count;
+		this.updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/kt/domain/user/Role.java
+++ b/src/main/java/com/kt/domain/user/Role.java
@@ -2,7 +2,8 @@ package com.kt.domain.user;
 
 public enum Role {
     USER,
-    ADMIN;
+    ADMIN,
+    SUPER_ADMIN;
 
     public String getKey() {
         return "ROLE_" + name();

--- a/src/main/java/com/kt/dto/cart/CartRequest.java
+++ b/src/main/java/com/kt/dto/cart/CartRequest.java
@@ -1,0 +1,28 @@
+package com.kt.dto.cart;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class CartRequest {
+
+	public record Add(
+
+		@NotNull
+		Long productId,
+
+		@Min(value = 1)
+		int count //추가한 수량
+
+	){
+
+	}
+
+	public record CountUpdate(
+
+		@Min(value = 1)
+		int count
+	){
+
+	}
+}

--- a/src/main/java/com/kt/dto/cart/CartResponse.java
+++ b/src/main/java/com/kt/dto/cart/CartResponse.java
@@ -1,0 +1,53 @@
+package com.kt.dto.cart;
+
+import java.time.LocalDateTime;
+
+import com.kt.domain.cartproduct.CartProduct;
+
+public class CartResponse {
+
+	public record Create(
+
+		String name,
+		int price,
+		int count
+
+	){
+		public static Create from(CartProduct cartProduct){
+
+			return new Create(
+
+				cartProduct.getProduct().getName(),
+				cartProduct.getProduct().getPrice(),
+				cartProduct.getCount()
+
+			);
+		}
+
+	}
+
+	public record Detail(
+
+		Long cartId,
+		Long productId,
+		String name,
+		int price,
+		int count,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+		//Long productPrice, //상품별 금액
+		//Long totalPrice //전체 금액
+
+	){
+
+	}
+
+	public record CountUpdate(
+
+		Long productId,
+		String name,
+		int count,
+		LocalDateTime updatedAt
+	){
+	}
+}

--- a/src/main/java/com/kt/repository/cart/CartProductRepository.java
+++ b/src/main/java/com/kt/repository/cart/CartProductRepository.java
@@ -1,0 +1,18 @@
+package com.kt.repository.cart;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.domain.cartproduct.CartProduct;
+import com.kt.repository.category.CategoryRepositoryCustom;
+
+//JPA가 제공하는 기본 메서드를 사용하는 메인 Repository
+public interface CartProductRepository extends JpaRepository<CartProduct,Long>, CartProductRepositoryCustom {
+
+	//장바구니에 들어갈 상품을 저장하거나 조회하는 역할
+	Optional<CartProduct> findByCartIdAndProductId(Long cartId, Long ProductId);
+
+	Optional<CartProduct> findByCartIdAndCart_UserId(Long cartId, Long userId);
+
+}

--- a/src/main/java/com/kt/repository/cart/CartProductRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/cart/CartProductRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.kt.repository.cart;
+
+import java.util.List;
+
+import com.kt.domain.cartproduct.CartProduct;
+import com.kt.dto.cart.CartResponse;
+
+public interface CartProductRepositoryCustom {
+
+	//장바구니 상세 조회를 위한 메서드
+	List<CartResponse.Detail> findCartDetailList(Long cartId);
+}

--- a/src/main/java/com/kt/repository/cart/CartProductRepositoryImpl.java
+++ b/src/main/java/com/kt/repository/cart/CartProductRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.kt.repository.cart;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.kt.domain.cartproduct.QCartProduct;
+import com.kt.domain.product.QProduct;
+import com.kt.dto.cart.CartResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CartProductRepositoryImpl implements CartProductRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<CartResponse.Detail> findCartDetailList(Long cartId) {
+		QCartProduct cartProduct = QCartProduct.cartProduct;
+		QProduct product = QProduct.product;
+
+		/**
+		 * 특정 장바구니(=cartId =사용자가 조회하고자 요청한 장바구니)에 담긴 상품들을 조회할건데,
+		 * 각 상품의 'id/이름/가격/담은날짜' 를 함께 조회해서
+		 * CartResponse 리스트로 반환하는 쿼리dsl
+		 */
+
+		 //Projections
+		 //특정 엔티티를 조회할때, 엔티티의 모든 값이 필요하지 않은 경우 필요한 값들만 조회할 수 있게 하는 기능
+
+		List<CartResponse.Detail> results = queryFactory
+			.select(Projections.fields(CartResponse.Detail.class,
+				cartProduct.id.as("cartId"), //as : 별칭 지정
+				product.id.as("productId"),
+				product.name,
+				product.price,
+				cartProduct.count,
+				cartProduct.createdAt,
+				cartProduct.updatedAt
+			))
+			.join(cartProduct.product, product)
+			//.join(cartProduct.cart, cart) //cart는 cart_id만 필요하므로 조인 필요x
+			.from(cartProduct)
+			.where(cartProduct.cart.id.eq(cartId)) //전달받은 ID랑 Cart 객체의 ID가 같은 장바구니를 조회
+			.orderBy(
+				cartProduct.updatedAt.desc().nullsLast(), //가장 최근에 수정한 상품을 가장 먼저 보여줌 //null이면 맨 아래로
+				cartProduct.createdAt.desc() //수정된적 없는 상품은 최근에 등록한 순서대로 보여줌
+			)
+			.fetch(); //실제 db조회가 일어나는 단계
+
+		return results;
+	}
+}

--- a/src/main/java/com/kt/repository/cart/CartRepository.java
+++ b/src/main/java/com/kt/repository/cart/CartRepository.java
@@ -1,0 +1,14 @@
+package com.kt.repository.cart;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.domain.cart.Cart;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+	//회원의 Cart를 찾는 쿼리 메서드
+
+	Optional<Cart> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/kt/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/kt/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.kt.security;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.common.api.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final JwtExceptionHandler exceptionHandler;
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        exceptionHandler.handle(response, ErrorCode.PERMISSION_DENIED);
+    }
+}

--- a/src/main/java/com/kt/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kt/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.kt.security;
+
+import com.kt.common.api.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final JwtExceptionHandler exceptionHandler;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        exceptionHandler.handle(response, ErrorCode.UNAUTHORIZED_CLIENT);
+    }
+}

--- a/src/main/java/com/kt/service/cart/CartService.java
+++ b/src/main/java/com/kt/service/cart/CartService.java
@@ -1,0 +1,129 @@
+package com.kt.service.cart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.kt.common.api.CustomException;
+import com.kt.common.api.ErrorCode;
+import com.kt.domain.cart.Cart;
+import com.kt.domain.cartproduct.CartProduct;
+import com.kt.dto.cart.CartRequest;
+import com.kt.dto.cart.CartResponse;
+import com.kt.repository.cart.CartProductRepository;
+import com.kt.repository.cart.CartProductRepositoryImpl;
+import com.kt.repository.cart.CartRepository;
+import com.kt.repository.product.ProductRepository;
+import com.kt.repository.user.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartService {
+
+	private final CartRepository cartRepository;
+	private final CartProductRepository cartProductRepository;
+	private final ProductRepository productRepository;
+	private final UserRepository userRepository;
+	private final CartProductRepositoryImpl cartProductRepositoryImpl;
+
+	//TODO : 반복되는 로직있으면 따로 메서드로 빼기
+
+	//장바구니 상품 추가/생성
+	public CartResponse.Create create(CartRequest.Add request, Long id){
+
+		//상품
+		var product = productRepository.findById(request.productId())
+			.orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+		//회원
+		var user = userRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		//유저에게 장바구니가 없으면 null 반환
+		var cart = cartRepository.findByUserId(user.getId()).orElse(null);
+
+		//null이면 cart 생성
+		if(cart == null){
+			cart = Cart.create(user);
+			cartRepository.save(cart);
+		}
+
+		//카트에 상품이 담겨 있는지 확인하고 없으면 null
+		var existCartProduct = cartProductRepository.findByCartIdAndProductId(cart.getId(),product.getId())
+			.orElse(null);
+
+		CartProduct finalCartProduct;
+
+		//null이 아니면 = 장바구니에 상품이 있으면, 수량 증가
+		if(existCartProduct != null){
+
+			existCartProduct.add(request.count());
+			finalCartProduct = existCartProduct;
+
+		}else{
+
+			//없으면 cartProduct 상품 생성하고 저장
+			var cartProduct = CartProduct.create(cart, product, request.count());
+			cartProductRepository.save(cartProduct);
+
+			finalCartProduct = cartProduct;
+		}
+
+		return CartResponse.Create.from(finalCartProduct);
+
+	}
+
+	//장바구니 조회(장바구니에 담긴 상품 리스트 조회)
+	public List<CartResponse.Detail> detail(Long id){
+
+		List<CartResponse.Detail> cartDetailList = new ArrayList<>();
+
+		/*
+		//회원
+		var user = userRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		 */
+
+		var cart = cartRepository.findByUserId(id).orElse(null);
+
+		if(cart == null){
+			return cartDetailList; //장바구니에 아무것도 없으면 빈 리스트 반환
+		}
+
+		//카트에 담긴 상품들을 찾아서 저장
+		cartDetailList = cartProductRepositoryImpl.findCartDetailList(cart.getId());
+
+		return cartDetailList;
+	}
+
+	//장바구니 상품 삭제
+	public void delete(Long cartProductId, Long userId){
+
+		CartProduct cartProduct = cartProductRepository.findByCartIdAndCart_UserId(cartProductId, userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+
+		cartProductRepository.delete(cartProduct);
+
+	}
+
+	//장바구니 상품 수량 변경
+	public CartResponse.CountUpdate countUpdate(Long id, CartRequest.CountUpdate request, Long cartProductId){
+
+		CartProduct cartProduct = cartProductRepository.findByCartIdAndCart_UserId(cartProductId, id)
+			.orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_NOT_FOUND));
+
+		 cartProduct.countUpdate(request.count());
+
+		return new CartResponse.CountUpdate(
+			cartProduct.getProduct().getId(),
+			cartProduct.getProduct().getName(),
+			cartProduct.getCount(),
+			cartProduct.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -1,0 +1,25 @@
+INSERT INTO users (
+    login_id,
+    password,
+    name,
+    email,
+    phone,
+    birthday,
+    gender,
+    role,
+    created_at,
+    updated_at,
+    deleted_at
+) VALUES (
+             'superadmin123',
+             '$2a$10$vSFHdT6/.UyT2MiB0usJ1erggGvV6MRM86xAEPadiaihhTJtwGXU2',
+             '총괄관리자',
+             'superadmin@example.com',
+             '010-0000-0000',
+             '1990-01-01',
+             'FEMALE',
+             'SUPER_ADMIN',
+             NOW(),
+             NOW(),
+             NULL
+         );

--- a/src/test/java/com/kt/common/AbstractRestDocsTest.java
+++ b/src/test/java/com/kt/common/AbstractRestDocsTest.java
@@ -54,8 +54,9 @@ public abstract class AbstractRestDocsTest {
 	// 테스트용 ID
 	protected static final Long DEFAULT_USER_ID = 1L;
 	protected static final Long DEFAULT_ADMIN_ID = 10000L;
+    protected static final Long DEFAULT_SUPER_ADMIN_ID = 99999L;
 
-	@BeforeEach
+    @BeforeEach
 	void setUp(RestDocumentationContextProvider restDocumentation) {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
 			.apply(springSecurity())
@@ -106,6 +107,19 @@ public abstract class AbstractRestDocsTest {
 			return request;
 		};
 	}
+
+    /** SUPER_ADMIN 토큰 */
+    protected RequestPostProcessor jwtSuperAdmin() {
+        return request -> {
+            String token = createAccessToken(
+                    DEFAULT_SUPER_ADMIN_ID,
+                    Role.SUPER_ADMIN.getKey()
+            );
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+            return request;
+        };
+    }
+
 
     @PostConstruct
     public void setUpObjectMapper() {

--- a/src/test/java/com/kt/controller/admin/AdminControllerTest.java
+++ b/src/test/java/com/kt/controller/admin/AdminControllerTest.java
@@ -31,9 +31,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 public class AdminControllerTest extends AbstractRestDocsTest {
 
-    private static final String ADMIN_URL_PREFIX = "/admins";
-    private static final String ADMIN_LOGIN_ID  = "PasswordTest123";
-    private static final String ADMIN_PASSWORD  = "PasswordTest123!";
+    private static final String ADMIN_URL_PREFIX = "/super-admin";
+    private static final String ADMIN_LOGIN_ID  = "superadmin123";
+    private static final String ADMIN_PASSWORD  = "SuperAdmin123!";
 
     @MockitoBean
     private StringRedisTemplate stringRedisTemplate;
@@ -100,7 +100,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                                     request,
                                     HttpMethod.POST,
                                     objectMapper
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isCreated())
                     .andDo(
@@ -126,7 +126,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                             null,
                             HttpMethod.GET,
                             objectMapper
-                    ).with(jwtAdmin())
+                    ).with(jwtSuperAdmin())
             )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data").isArray())
@@ -160,7 +160,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.GET,
                                     objectMapper,
                                     adminId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(adminId))
@@ -201,7 +201,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.PATCH,
                                     objectMapper,
                                     adminId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(adminId))
@@ -234,7 +234,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.DELETE,
                                     objectMapper,
                                     adminId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isNoContent())
                     .andDo(
@@ -261,7 +261,7 @@ public class AdminControllerTest extends AbstractRestDocsTest {
                             HttpMethod.PATCH,
                             objectMapper,
                             adminId
-                    ).with(jwtAdmin())
+                    ).with(jwtSuperAdmin())
             )
                     .andExpect(status().isNoContent())
                     .andDo(

--- a/src/test/java/com/kt/controller/admin/AdminUserControllerTest.java
+++ b/src/test/java/com/kt/controller/admin/AdminUserControllerTest.java
@@ -1,4 +1,4 @@
-package com.kt.controller.user;
+package com.kt.controller.admin;
 
 import com.kt.common.AbstractRestDocsTest;
 import com.kt.common.RestDocsFactory;
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpMethod;
@@ -34,10 +33,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 public class AdminUserControllerTest extends AbstractRestDocsTest {
 
-    private static final String ADMIN_USERS_URL = "/admin/users";
+    private static final String ADMIN_USERS_URL = "/super-admin/users";
 
-    private static final String ADMIN_LOGIN_ID  = "adminUser123";
-    private static final String ADMIN_PASSWORD  = "AdminTest123!";
+    private static final String ADMIN_LOGIN_ID  = "superadmin123";
+    private static final String ADMIN_PASSWORD  = "SuperAdminTest123!";
 
     @MockitoBean
     private StringRedisTemplate stringRedisTemplate;
@@ -94,7 +93,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.GET,
                                     objectMapper,
                                     userId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(userId))
@@ -126,7 +125,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     null,
                                     HttpMethod.GET,
                                     objectMapper
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data").isArray())
@@ -164,7 +163,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.PATCH,
                                     objectMapper,
                                     userId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(userId))
@@ -197,7 +196,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.DELETE,
                                     objectMapper,
                                     userId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isNoContent())
                     .andDo(
@@ -230,7 +229,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.PATCH,
                                     objectMapper,
                                     userId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isNoContent())
                     .andDo(
@@ -262,7 +261,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                                     HttpMethod.PATCH,
                                     objectMapper,
                                     userId
-                            ).with(jwtAdmin())
+                            ).with(jwtSuperAdmin())
                     )
                     .andExpect(status().isNoContent())
                     .andDo(
@@ -296,7 +295,7 @@ public class AdminUserControllerTest extends AbstractRestDocsTest {
                             HttpMethod.PATCH,
                             objectMapper,
                             userId
-                    ).with(jwtAdmin())
+                    ).with(jwtSuperAdmin())
             )
                     .andExpect(status().isNoContent())
                     .andDo(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #124 

## 📝작업 내용

> 유저 관리 및 관리자 관리 기능을 SUPER_ADMIN으로 분리

> Spring Security 설정 수정
>> SUPER_ADMIN 권한 추가
>> Role에 SUPER_ADMIN 추가 및 권한 계층(RoleHierarchy) 적용
>> 인증 실패(401) / 권한 부족(403) 커스텀 에러 생성

> 관리자/유저 관련 컨트롤러 테스트 코드 수정

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 판매사와 admin의 분리가 필요하다 생각하는데 나누는 기준이 모호해 회의 후 권한을 나누려 합니다. 그래서 우선은 유저 관리 기능, 관리자 관리 기능만 super_admin으로 권한 부여 했습니다!