### PR TITLE
feat: 카카오 로그인

### DIFF
--- a/src/main/java/com/kt/common/api/ErrorCode.java
+++ b/src/main/java/com/kt/common/api/ErrorCode.java
@@ -21,6 +21,14 @@ public enum ErrorCode {
 	PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
 	INTERNAL_SERVER_ERROR_JWT_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "JWT 예외 응답 처리 중 오류가 발생했습니다."),
     PASSWORD_RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 리셋 토큰이 유효하지 않습니다."),
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 토큰 발급 요청에 실패했습니다."),
+    KAKAO_TOKEN_RESPONSE_INVALID(HttpStatus.BAD_GATEWAY, "카카오 토큰 응답이 올바르지 않습니다."),
+    KAKAO_TOKEN_REQUEST_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "카카오 서버 응답 시간이 초과되었습니다."),
+    KAKAO_USERINFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패했습니다."),
+    KAKAO_USERINFO_RESPONSE_INVALID(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 응답이 올바르지 않습니다."),
+    KAKAO_USERINFO_REQUEST_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "카카오 사용자 정보 조회 시간이 초과되었습니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "카카오 연결 끊기에 실패했습니다."),
+
 	// ---------------- USER -------------------
 	INVALID_USER_ID(HttpStatus.CONFLICT,"이미 사용 중인 아이디입니다."),
 	INVALID_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/com/kt/common/config/SecurityConfig.java
+++ b/src/main/java/com/kt/common/config/SecurityConfig.java
@@ -51,14 +51,9 @@ public class SecurityConfig {
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/users/signup", "/", "/auth/login","/auth/reissue","/swagger-ui.html",
-                                "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/super-admin/**").hasRole("SUPER_ADMIN")
-                        .requestMatchers("/users/signup", "/admins/signup", "/", "/auth/login", "/auth/reissue",
-                                "/auth/reset-password/request", "/auth/reset-password/verify", "/auth/update-password", "/auth/find-id",
+                        .requestMatchers("/users/signup", "/admins/signup", "/", "/auth/login", "/auth/reissue", "/auth/login/kakao/**",
+                                "/auth/reset-password/request", "/auth/reset-password/verify", "/auth/update-password", "/auth/find-id", "/auth/login/kakao",
                                 "/swagger-ui.html", "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/users/signup", "/", "/auth/login","/auth/reissue","/swagger-ui.html",
-                                "/swagger-ui/**","/api-docs/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/super-admin/**").hasRole("SUPER_ADMIN")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/src/main/java/com/kt/common/oauth/KakaoUtil.java
+++ b/src/main/java/com/kt/common/oauth/KakaoUtil.java
@@ -1,0 +1,114 @@
+package com.kt.common.oauth;
+
+import com.kt.common.api.CustomException;
+import com.kt.common.api.ErrorCode;
+import com.kt.config.oauth.KakaoAuthProperties;
+import com.kt.dto.auth.oauth.KakaoLoginResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoUtil {
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+
+    private final RestTemplate restTemplate;
+    private final KakaoAuthProperties kakaoAuthProperties;
+
+    public KakaoLoginResponse.OAuthToken requestToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoAuthProperties.client());
+        params.add("client_secret", kakaoAuthProperties.secret());
+        params.add("redirect_uri", kakaoAuthProperties.redirect());
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<KakaoLoginResponse.OAuthToken> response = restTemplate.exchange(
+                    TOKEN_URL, HttpMethod.POST, request, KakaoLoginResponse.OAuthToken.class);
+            KakaoLoginResponse.OAuthToken body = response.getBody();
+            if(body == null) {
+                throw new CustomException(ErrorCode.KAKAO_TOKEN_RESPONSE_INVALID);
+            }
+            return body;
+        } catch (HttpStatusCodeException e) {
+            log.error("Kakao token request failed. status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+
+        } catch (ResourceAccessException e) {
+            log.error("Kakao token request network error: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_TIMEOUT);
+
+        } catch (RestClientException e) {
+            log.error("Kakao token request failed. code={}, msg={}", code, e.getMessage());
+            throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    public KakaoLoginResponse.KakaoUserInfo requestUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoLoginResponse.KakaoUserInfo> response = restTemplate.exchange(USER_INFO_URL, HttpMethod.GET, request, KakaoLoginResponse.KakaoUserInfo.class);
+            KakaoLoginResponse.KakaoUserInfo body = response.getBody();
+            if(body == null) {
+                throw new CustomException(ErrorCode.KAKAO_USERINFO_RESPONSE_INVALID);
+            }
+            return body;
+        } catch (HttpStatusCodeException e) {
+            log.error("Kakao userinfo request failed. status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new CustomException(ErrorCode.KAKAO_USERINFO_REQUEST_FAILED);
+        } catch (ResourceAccessException e) {
+            log.error("Kakao userinfo request network error: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.KAKAO_USERINFO_REQUEST_TIMEOUT);
+
+        } catch (RestClientException e) {
+            log.error("Kakao userinfo request failed. msg={}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.KAKAO_USERINFO_REQUEST_FAILED);
+        }
+    }
+
+    public void unlinkByAdminKey(String providerUserId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK "+kakaoAuthProperties.adminKey());
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", providerUserId);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            restTemplate.exchange(UNLINK_URL, HttpMethod.POST, request, String.class);
+        } catch (HttpStatusCodeException e) {
+            log.error("Kakao unlink failed. status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+        } catch (RestClientException e) {
+            log.error("Kakao unlink failed. msg={}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/kt/config/RestTemplateConfig.java
+++ b/src/main/java/com/kt/config/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+package com.kt.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(5000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/kt/config/oauth/KakaoAuthProperties.java
+++ b/src/main/java/com/kt/config/oauth/KakaoAuthProperties.java
@@ -1,0 +1,11 @@
+package com.kt.config.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.kakao.auth")
+public record KakaoAuthProperties(
+        String client,
+        String secret,
+        String adminKey,
+        String redirect
+) {}

--- a/src/main/java/com/kt/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/controller/auth/AuthController.java
@@ -64,4 +64,10 @@ public class AuthController {
         authService.updatePassword(request);
         return ApiResponseEntity.empty();
     }
+
+    @GetMapping("/login/kakao")
+    public ApiResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") String code) {
+        LoginResponse response = authService.kakaoLogin(code);
+        return ApiResponseEntity.success(response);
+    }
 }

--- a/src/main/java/com/kt/domain/auth/OAuthAccount.java
+++ b/src/main/java/com/kt/domain/auth/OAuthAccount.java
@@ -1,0 +1,60 @@
+package com.kt.domain.auth;
+
+import com.kt.common.jpa.BaseSoftDeleteEntity;
+import com.kt.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "oauth_account",
+uniqueConstraints = {
+        @UniqueConstraint(name = "uk_oauth_provider_provider_id", columnNames = {"provider", "provider_user_id"})
+})
+public class OAuthAccount extends BaseSoftDeleteEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OAuthProvider provider;
+
+    @Column(nullable = false, length = 64)
+    private String providerUserId;
+
+    private String email;
+    private String nickname;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public OAuthAccount(OAuthProvider provider, String providerUserId, String email, String nickname, User user) {
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.email = email;
+        this.nickname = nickname;
+        this.user = user;
+    }
+
+    public static OAuthAccount link(OAuthProvider provider, String providerUserId, String email, String nickname, User user) {
+        return new OAuthAccount(provider, providerUserId, email, nickname, user);
+    }
+
+    public void softDelete(Long deleterId) {
+        markDeleted(deleterId);
+    }
+
+    public void restoreAndRelink (User newUser, String email, String nickname) {
+        this.deleted = false;
+        this.deletedAt = null;
+        this.deletedBy = null;
+
+        this.user = newUser;
+        this.email = email;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/kt/domain/auth/OAuthProvider.java
+++ b/src/main/java/com/kt/domain/auth/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.kt.domain.auth;
+
+public enum OAuthProvider {
+    KAKAO
+    // naver, google
+}

--- a/src/main/java/com/kt/dto/auth/oauth/KakaoLoginResponse.java
+++ b/src/main/java/com/kt/dto/auth/oauth/KakaoLoginResponse.java
@@ -1,0 +1,38 @@
+package com.kt.dto.auth.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoLoginResponse {
+
+    public record OAuthToken (
+            @JsonProperty("token_type") String tokenType,
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("expires_in") Integer expiresIn,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("refresh_token_expires_in") Integer refreshTokenExpiresIn,
+            String scope
+    ) {}
+
+    public record KakaoUserInfo (
+            Long id,
+            @JsonProperty("kakao_account") KakaoAccount kakaoAccount,
+            Properties properties
+    ) {
+        public String emailOrNull() {
+            return kakaoAccount != null ? kakaoAccount.email() :  null;
+        }
+
+        public String nicknameOrNull() {
+            return properties != null ? properties.nickname : null;
+        }
+    }
+
+    public record KakaoAccount(
+            String email,
+            @JsonProperty("has_email") Boolean hasEmail
+    ) {}
+
+    public record Properties(
+            String nickname
+    ) {}
+}

--- a/src/main/java/com/kt/repository/auth/OAuthAccountRepository.java
+++ b/src/main/java/com/kt/repository/auth/OAuthAccountRepository.java
@@ -1,0 +1,13 @@
+package com.kt.repository.auth;
+
+import com.kt.domain.auth.OAuthAccount;
+import com.kt.domain.auth.OAuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
+    Optional<OAuthAccount> findByProviderAndProviderUserId(OAuthProvider provider, String providerUserId);
+
+    Optional<OAuthAccount> findByUserIdAndDeletedFalse(Long userId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
       ssl:
         enabled: ${redis.ssl.enabled:false}
       timeout: 5000
+  kakao:
+    auth:
+      redirect: http://localhost:8080/auth/login/kakao
+      client: ${KAKAO_AUTH_CLIENT}
+      secret: ${KAKAO_AUTH_SECRET}
+      admin-key: ${KAKAO_AUTH_ADMIN_KEY}
+
 
 jwt:
   secret: ${kt.jwt.secret:1234567890123456789012345678901234}
@@ -39,7 +46,7 @@ delivery:
 
 aws:
   ses:
-    access-key: dummy-main-access-key
-    secret-key: dummy-main-secret-key
-    send-mail-from: dummy-main-email@example.com
+    access-key: ${AWS_SES_ACCESS_KEY}
+    secret-key: ${AWS_SES_SECRET_KEY}
+    send-mail-from: whtndus0809@gmail.com
   region: ap-northeast-2


### PR DESCRIPTION
## #️⃣연관된 이슈

> #130 

## 📝작업 내용

> 카카오 OAuth 설정 추가
카카오 토큰 발급 및 사용자 정보 조회 유틸 구현

>OAuthAccount 엔티티 및 레포지토리 추가
카카오 로그인/회원가입 서비스 로직 구현
카카오 로그인 API 엔드포인트 추가

>카카오 로그인 시 탈퇴 사용자 처리 로직 적용

>카카오 OAuth 설정 yml 추가

> 카카오 로그인 API 테스트 코드 작성

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?